### PR TITLE
Fix AttachmentsCountValidator so it also works if Content-disposition…

### DIFF
--- a/src/main/kotlin/nl/avisi/kotlinwebtest/soap/Validation.kt
+++ b/src/main/kotlin/nl/avisi/kotlinwebtest/soap/Validation.kt
@@ -212,8 +212,8 @@ class AttachmentsCountValidator(private val expectedValue: Int) : Validator<Soap
         return when {
             response.http is MultipartHttpResponse -> {
                 response.http.parts.forEach {
-                    it.headers.forEach {
-                        if (it.value.contains("attachment")) value++
+                    it.headers.forEach { httpHeader ->
+                        if (httpHeader.value.contains("attachment") || httpHeader.name.contains("Content-ID")) value++
                     }
                 }
                 if (value == expectedValue) return success()


### PR DESCRIPTION
… is not used (Content-disposition is not required in MTOM attachments).